### PR TITLE
Establish the early stage tests of the metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,4 @@ jobs:
           args: "bazel build //src:all"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel test //src:all"
-      - run: ls bazel-out/*/*/*/* && cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
-        if: failure()
+          args: "bazel test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           args: "bazel test //src:all"
-      - run: cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
+      - run: ls && cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: "Build"
-on:
-  push:
-    branches:
-    - master
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           args: "bazel test //src:all"
+      - run: cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,6 @@ jobs:
           args: "bazel build //src:all"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel test //src:all ; cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log"
+          args: "bazel test //src:all"
+      - run: cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
+        if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           args: "bazel test //src:all"
-      - run: ls && cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
+      - run: ls bazel-out/*/*/*/* && cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,4 @@ jobs:
           args: "bazel build //src:all"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel test //src:all"
-      - run: cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log
+          args: "bazel test //src:all ; cat bazel-out/k8-fastbuild/testlogs/src/awscli_metadata_test/test.log"

--- a/src/test_configs/metadata.yaml
+++ b/src/test_configs/metadata.yaml
@@ -1,14 +1,16 @@
+schemaVersion: 2.0.0
+
 metadataTest:
   env:
     - key: CARDBOARDCI_WORKSPACE
       value: /workspace
   labels:
-    - key: 'maintainer'
-      value: 'CardboardCI'
-    - key: 'org.label-schema.schema-version'
-      value: '1.0'
-    - key: 'org.label-schema.vendor'
-      value: 'cardboardci'
-    - key: 'org.label-schema.architecture'
-      value: 'amd64'
+    - key: "maintainer"
+      value: "CardboardCI"
+    - key: "org.label-schema.schema-version"
+      value: "1.0"
+    - key: "org.label-schema.vendor"
+      value: "cardboardci"
+    - key: "org.label-schema.architecture"
+      value: "amd64"
   volumes: ["/workspace"]


### PR DESCRIPTION
Set up running of the container structure tests for the image. This batch will ensure that certain metadata properties are enabled for the image.

For now, the tests are only factoring in metadata as I have not installed any of the dependencies (python/etc). `command` will exist for later when ensuring that all the tools exist.