### PR TITLE
Install python dependencies on image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/.github/workflows/main.bash
+++ b/.github/workflows/main.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all  || true
+# chmod 777 /tmp/installer.sh
+chmod +x /tmp/installer.sh
+bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all

--- a/.github/workflows/main.bash
+++ b/.github/workflows/main.bash
@@ -1,5 +1,0 @@
-#!/bin/bash
-bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all  || true
-# chmod 777 /tmp/installer.sh
-chmod +x /tmp/installer.sh
-bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,5 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           # entrypoint: /bin/bash
-          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli && bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
+          # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli && bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://l.gcr.io/google/bazel
+      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel --output_base=/workspace/bazel_outputs build //src:awscli"
-      - uses: docker://l.gcr.io/google/bazel
+          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
+      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel --output_base=/workspace/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel build //src:awscli"
+          args: "bazel build --output_base=/workspace/bazel_outputs //src:awscli"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           args: "bazel test --output_base=/workspace/bazel_outputs --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
           args: "bazel build //src:awscli"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel test --test_output=all //src:all"
+          args: "bazel test --output_base=/workspace/bazel_outputs --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel build //src:all"
+          args: "bazel build //src:awscli"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           args: "bazel test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           # entrypoint: /bin/bash
-          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-          # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli && bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+          # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
+          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,6 @@ jobs:
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
           # entrypoint: /bin/bash
+          args: "bash .github/workflows/main.bash"
           # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-          args: "bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all"
+          # args: "bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          entrypoint: /bin/bash
+          # entrypoint: /bin/bash
           args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli && bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
+      - uses: docker://gcr.io/google/bazel
         with:
-          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
+          args: "bazel --output_base=/workspace/bazel_outputs build //src:awscli"
+      - uses: docker://gcr.io/google/bazel
         with:
-          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/workspace/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://gcr.io/google/bazel
+      - uses: docker://l.gcr.io/google/bazel
         with:
           args: "bazel --output_base=/workspace/bazel_outputs build //src:awscli"
-      - uses: docker://gcr.io/google/bazel
+      - uses: docker://l.gcr.io/google/bazel
         with:
           args: "bazel --output_base=/workspace/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-        with:
-          # entrypoint: /bin/bash
-          args: "bash .github/workflows/main.bash"
-          # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-          # args: "bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all"
+      - name: bazel test
+        run: |
+        curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+        echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+        sudo apt update && sudo apt install bazel
+
+        bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all
+      ### Run install bazel
+      # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
+      #   with:
+      #     # entrypoint: /bin/bash
+      #     args: "bash .github/workflows/main.bash"
+      #     # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
+      #     # args: "bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         run: |
           curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
           echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-          sudo apt update && sudo apt install bazel
+          sudo apt-get update && sudo apt-get install -y bazel
 
-          bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all
+          bazel test --test_output=all //src:all
       ### Run install bazel
       # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
       #   with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel --output_base=/workspace/bazel_outputs build //src:awscli"
+          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel --output_base=/workspace/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: bazel test
         run: |
-          curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+          curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
           echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-          apt update && apt install bazel
+          sudo apt update && sudo apt install bazel
 
           bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all
       ### Run install bazel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-        with:
-          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-      - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-        with:
-          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+        run: |
+          bazel --output_base=/tmp/bazel_outputs build //src:awscli
+          bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all
+      # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
+      #   with:
+      #     args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
+      # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
+      #   with:
+      #     args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           # entrypoint: /bin/bash
           # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-          args: "bazel --output_base=/github/workspace/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           # entrypoint: /bin/bash
           # args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-          args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+          args: "bazel --output_base=/github/workspace/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,11 @@ jobs:
       - uses: actions/checkout@v1
       - name: bazel test
         run: |
-        curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-        echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        sudo apt update && sudo apt install bazel
+          curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+          echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+          apt update && apt install bazel
 
-        bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all
+          bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all
       ### Run install bazel
       # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
       #   with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: bazel test
         run: |
           curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-          echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+          echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
           sudo apt update && sudo apt install bazel
 
           bazel --output_base=/github/home/bazel_outputs test --test_output=all //src:all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-        run: |
-          bazel --output_base=/tmp/bazel_outputs build //src:awscli
-          bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all
-      # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-      #   with:
-      #     args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli"
-      # - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
-      #   with:
-      #     args: "bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"
+        with:
+          entrypoint: /bin/bash
+          args: "bazel --output_base=/tmp/bazel_outputs build //src:awscli && bazel --output_base=/tmp/bazel_outputs test --test_output=all //src:all"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel build --output_base=/workspace/bazel_outputs //src:awscli"
+          args: "bazel --output_base=/workspace/bazel_outputs build //src:awscli"
       - uses: docker://gcr.io/bazel-public/ubuntu1804:java11
         with:
-          args: "bazel test --output_base=/workspace/bazel_outputs --test_output=all //src:all"
+          args: "bazel --output_base=/workspace/bazel_outputs test --test_output=all //src:all"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,9 +27,9 @@ load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 
 container_pull(
     name = "ci_core",
-    registry = "l.gcr.io",
-    repository = "google/ubuntu1604",
-    tag = "latest",
+    registry = "docker.io",
+    repository = "ubuntu",
+    tag = "focal-20191030",
 )
 
 http_file(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,8 @@ container_pull(
     name = "ci_core",
     registry = "docker.io",
     repository = "ubuntu",
-    tag = "focal-20191030",
+    digest = "sha256:cb6a3a1298c73e3248b6b07ef3c78a14df4bade77b4be1ad725f8f5f2785e348"
+    # tag = "focal-20191030",
 )
 
 http_file(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,12 +31,3 @@ container_pull(
     repository = "library/ubuntu",
     digest = "sha256:cb6a3a1298c73e3248b6b07ef3c78a14df4bade77b4be1ad725f8f5f2785e348"
 )
-
-http_file(
-    name = "gcloud_archive",
-    downloaded_file_path = "google-cloud-sdk.tar.gz",
-    sha256 = "a2205e35b11136004d52d47774762fbec9145bf0bda74ca506f52b71452c570e",
-    urls = [
-        "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-220.0.0-linux-x86_64.tar.gz",
-    ],
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,10 +27,9 @@ load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 
 container_pull(
     name = "ci_core",
-    registry = "docker.io",
-    repository = "ubuntu",
+    registry = "index.docker.io",
+    repository = "library/ubuntu",
     digest = "sha256:cb6a3a1298c73e3248b6b07ef3c78a14df4bade77b4be1ad725f8f5f2785e348"
-    # tag = "focal-20191030",
 )
 
 http_file(

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,11 +1,34 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
+## Packages
+
+download_pkgs(
+    name = "pkgs_dwnld",
+    image_tar = "@ci_core//image",
+    packages = [
+        "python",
+        "python-dev",
+        "python-pip",
+        "python3",
+        "python3-pip",
+    ],
+)
+
+install_pkgs(
+    name = "pkgs",
+    image_tar = "@ci_core//image",
+    installables_tar = ":pkgs_dwnld//tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "pkgs",
+)
+
+
 ## Container
 
 container_image(
     name = "awscli",
-    base = "@ci_core//image",
+    base = ":pkgs//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,14 +17,19 @@ download_pkgs(
     ],
 )
 
+container_image(
+    name = "pkgs_wrapper",
+    base = "@ci_core//image",
+    entrypoint = ["/bin/bash"],
+)
+
 install_pkgs(
     name = "pkgs",
-    image_tar = "@ci_core//image",
+    image_tar = ":pkgs_wrapper.tar",
     installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",
 )
-
 
 ## Container
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -35,7 +35,8 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = "@ci_core//image",
+    base = ":pkgs.tar",
+    # base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },
@@ -60,8 +61,6 @@ container_image(
         "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
         # "org.label-schema.vcs-ref": "{vcs_ref}",
     },
-    # base = ":pkgs.tar",
-    tars = [":pkgs.tar"],
 
     # The path /workspace is made available for all development work
     volumes = [

--- a/src/BUILD
+++ b/src/BUILD
@@ -9,7 +9,6 @@ download_pkgs(
     name = "pkgs_dwnld",
     image_tar = "@ci_core//image",
     packages = [
-        "bash",
         "python",
         "python-dev",
         "python-pip",

--- a/src/BUILD
+++ b/src/BUILD
@@ -9,6 +9,7 @@ download_pkgs(
     name = "pkgs_dwnld",
     image_tar = "@ci_core//image",
     packages = [
+        "bash",
         "python",
         "python-dev",
         "python-pip",

--- a/src/BUILD
+++ b/src/BUILD
@@ -72,6 +72,11 @@ container_image(
 
 # Tests
 
+container_image(
+    name = "awscli_test",
+    base = ":awscli.tar",
+)
+
 container_test(
     name = "awscli_metadata_test",
     configs = ["//src/test_configs:metadata.yaml"],
@@ -81,5 +86,5 @@ container_test(
 container_test(
     name = "awscli_command_test",
     configs = ["//src/test_configs:command.yaml"],
-    image = ":awscli",
+    image = ":awscli_test",
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -36,7 +36,7 @@ install_pkgs(
 container_image(
     name = "awscli",
     base = ":pkgs.tar",
-    entrypoint = [],
+    entrypoint = ["/bin/sh"],
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/BUILD
+++ b/src/BUILD
@@ -74,3 +74,9 @@ container_test(
     configs = ["//src/test_configs:metadata.yaml"],
     image = ":awscli",
 )
+
+container_test(
+    name = "awscli_command_test",
+    configs = ["//src/test_configs:command.yaml"],
+    image = ":awscli",
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -36,6 +36,7 @@ install_pkgs(
 container_image(
     name = "awscli",
     base = ":pkgs.tar",
+    entrypoint = [],
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,16 +17,9 @@ download_pkgs(
     ],
 )
 
-# container_image(
-#     name = "pkgs_wrapper",
-#     base = "@ci_core//image",
-#     entrypoint = ["/bin/bash"],
-# )
-
 install_pkgs(
     name = "pkgs",
     image_tar = "@ci_core//image",
-    # image_tar = ":pkgs_wrapper.tar",
     installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",
@@ -37,7 +30,6 @@ install_pkgs(
 container_image(
     name = "awscli",
     base = ":pkgs.tar",
-    # base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },
@@ -60,14 +52,13 @@ container_image(
         "org.label-schema.distribution-scope": "public",
         "org.label-schema.vcs-type": "git",
         "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
-        # "org.label-schema.vcs-ref": "{vcs_ref}",
     },
 
     # The path /workspace is made available for all development work
-    # volumes = [
-    #     "/workspace",
-    # ],
-    # workdir = "/workspace",
+    volumes = [
+        "/workspace",
+    ],
+    workdir = "/workspace",
 )
 
 # Tests

--- a/src/BUILD
+++ b/src/BUILD
@@ -66,6 +66,7 @@ container_image(
     volumes = [
         "/workspace",
     ],
+    workdir = "/workspace"
 )
 
 # Tests

--- a/src/BUILD
+++ b/src/BUILD
@@ -30,7 +30,7 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = ":pkgs//image",
+    base = ":pkgs.tar",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/BUILD
+++ b/src/BUILD
@@ -36,7 +36,8 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = ":pkgs.tar",
+    base = ":pkgs",
+    # base = ":pkgs.tar",
     # base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
@@ -72,11 +73,6 @@ container_image(
 
 # Tests
 
-container_image(
-    name = "awscli_test",
-    base = ":awscli.tar",
-)
-
 container_test(
     name = "awscli_metadata_test",
     configs = ["//src/test_configs:metadata.yaml"],
@@ -86,5 +82,5 @@ container_test(
 container_test(
     name = "awscli_command_test",
     configs = ["//src/test_configs:command.yaml"],
-    image = ":awscli_test",
+    image = ":awscli",
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -20,7 +20,7 @@ download_pkgs(
 install_pkgs(
     name = "pkgs",
     image_tar = "@ci_core//image",
-    installables_tar = ":pkgs_dwnld//tar",
+    installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -36,9 +36,7 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = ":pkgs",
-    # base = ":pkgs.tar",
-    # base = "@ci_core//image",
+    base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },
@@ -63,6 +61,9 @@ container_image(
         "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
         # "org.label-schema.vcs-ref": "{vcs_ref}",
     },
+    tars = [
+        ":pkgs.tar",
+    ],
 
     # The path /workspace is made available for all development work
     volumes = [

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 
 ## Packages
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -35,8 +35,7 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = ":pkgs.tar",
-    entrypoint = ["/bin/sh"],
+    base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },
@@ -61,12 +60,14 @@ container_image(
         "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
         # "org.label-schema.vcs-ref": "{vcs_ref}",
     },
+    # base = ":pkgs.tar",
+    tars = [":pkgs.tar"],
 
     # The path /workspace is made available for all development work
     volumes = [
         "/workspace",
     ],
-    workdir = "/workspace"
+    workdir = "/workspace",
 )
 
 # Tests

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,16 +17,16 @@ download_pkgs(
     ],
 )
 
-container_image(
-    name = "pkgs_wrapper",
-    base = "@ci_core//image",
-    entrypoint = ["/bin/bash"],
-)
+# container_image(
+#     name = "pkgs_wrapper",
+#     base = "@ci_core//image",
+#     entrypoint = ["/bin/bash"],
+# )
 
 install_pkgs(
     name = "pkgs",
-    # image_tar = "@ci_core//image",
-    image_tar = ":pkgs_wrapper.tar",
+    image_tar = "@ci_core//image",
+    # image_tar = ":pkgs_wrapper.tar",
     installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",
@@ -36,7 +36,8 @@ install_pkgs(
 
 container_image(
     name = "awscli",
-    base = "@ci_core//image",
+    base = ":pkgs.tar",
+    # base = "@ci_core//image",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },
@@ -61,15 +62,12 @@ container_image(
         "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
         # "org.label-schema.vcs-ref": "{vcs_ref}",
     },
-    tars = [
-        ":pkgs.tar",
-    ],
 
     # The path /workspace is made available for all development work
-    volumes = [
-        "/workspace",
-    ],
-    workdir = "/workspace",
+    # volumes = [
+    #     "/workspace",
+    # ],
+    # workdir = "/workspace",
 )
 
 # Tests

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,16 +17,16 @@ download_pkgs(
     ],
 )
 
-# container_image(
-#     name = "pkgs_wrapper",
-#     base = "@ci_core//image",
-#     entrypoint = ["/bin/bash"],
-# )
+container_image(
+    name = "pkgs_wrapper",
+    base = "@ci_core//image",
+    entrypoint = ["/bin/bash"],
+)
 
 install_pkgs(
     name = "pkgs",
-    image_tar = "@ci_core//image",
-    # image_tar = ":pkgs_wrapper.tar",
+    # image_tar = "@ci_core//image",
+    image_tar = ":pkgs_wrapper.tar",
     installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",

--- a/src/BUILD
+++ b/src/BUILD
@@ -17,15 +17,16 @@ download_pkgs(
     ],
 )
 
-container_image(
-    name = "pkgs_wrapper",
-    base = "@ci_core//image",
-    entrypoint = ["/bin/bash"],
-)
+# container_image(
+#     name = "pkgs_wrapper",
+#     base = "@ci_core//image",
+#     entrypoint = ["/bin/bash"],
+# )
 
 install_pkgs(
     name = "pkgs",
-    image_tar = ":pkgs_wrapper.tar",
+    image_tar = "@ci_core//image",
+    # image_tar = ":pkgs_wrapper.tar",
     installables_tar = ":pkgs_dwnld.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "pkgs",

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -2,18 +2,18 @@ schemaVersion: 2.0.0
 
 commandTests:
   - name: "python2_test"
-    command: "python"
-    args: ["-V"]
+    command: "which"
+    args: ["python"]
     expectedError: ["Python 2\\..*"]
   - name: "python3_test"
-    command: "python3"
-    args: ["-V"]
+    command: "which"
+    args: ["python3"]
     expectedOutput: ["Python 3\\..*"]
   - name: "pip_test"
-    command: "pip"
-    args: ["-V"]
+    command: "which"
+    args: ["pip"]
     expectedOutput: ["pip \\d+\\..*"]
   - name: "pip3_test"
-    command: "pip3"
-    args: ["-V"]
+    command: "which"
+    args: ["pip3"]
     expectedOutput: ["pip \\d+\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -4,16 +4,16 @@ commandTests:
   - name: "python2_test"
     command: "which"
     args: ["python"]
-    expectedError: ["Python 2\\..*"]
+    expectedOutput: ["/usr/bin/python"]
   - name: "python3_test"
     command: "which"
     args: ["python3"]
-    expectedOutput: ["Python 3\\..*"]
+    expectedOutput: ["/usr/bin/python3"]
   - name: "pip_test"
     command: "which"
     args: ["pip"]
-    expectedOutput: ["pip \\d+\\..*"]
+    expectedOutput: ["/usr/bin/pip"]
   - name: "pip3_test"
     command: "which"
     args: ["pip3"]
-    expectedOutput: ["pip \\d+\\..*"]
+    expectedOutput: ["/usr/bin/pip3"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -2,18 +2,18 @@ schemaVersion: 2.0.0
 
 commandTests:
   - name: "python2_test"
-    command: "/usr/bin/python"
+    command: "python"
     args: ["-V"]
     expectedError: ["Python 2\\..*"]
   - name: "python3_test"
-    command: "/usr/bin/python3"
+    command: "python3"
     args: ["-V"]
     expectedOutput: ["Python 3\\..*"]
   - name: "pip_test"
-    command: "/usr/bin/pip"
+    command: "pip"
     args: ["-V"]
     expectedOutput: ["pip \\d+\\..*"]
   - name: "pip3_test"
-    command: "/usr/bin/pip3"
+    command: "pip3"
     args: ["-V"]
     expectedOutput: ["pip \\d+\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -2,18 +2,18 @@ schemaVersion: 2.0.0
 
 commandTests:
   - name: "python2_test"
-    command: "python"
+    command: "/usr/bin/python"
     args: ["-V"]
     expectedError: ["Python 2\\..*"]
   - name: "python3_test"
-    command: "python3"
+    command: "/usr/bin/python3"
     args: ["-V"]
     expectedOutput: ["Python 3\\..*"]
   - name: "pip_test"
-    command: "pip"
+    command: "/usr/bin/pip"
     args: ["-V"]
     expectedOutput: ["pip \\d+\\..*"]
   - name: "pip3_test"
-    command: "pip3"
+    command: "/usr/bin/pip3"
     args: ["-V"]
     expectedOutput: ["pip \\d+\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -1,6 +1,10 @@
 schemaVersion: 2.0.0
 
 commandTests:
+  - name: "ls_test"
+    command: "ls"
+    args: ["/tmp/"]
+    expectedOutput: ["."]
   - name: "python2_test"
     command: "which"
     args: ["python"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -3,7 +3,7 @@ schemaVersion: 2.0.0
 commandTests:
   - name: "ls_test"
     command: "ls"
-    args: ["/tmp/"]
+    args: ["/usr/bin/"]
     expectedOutput: ["."]
   - name: "python2_test"
     command: "which"

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -13,6 +13,9 @@ fileExistenceTests:
   - name: "pip3_test"
     path: "/usr/bin/pip3"
     shouldExist: true
+  - name: "grep_test"
+    path: "/usr/bin/grep"
+    shouldExist: true
 
 # commandTests:
 #   - name: "ls_test"

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -1,23 +1,37 @@
 schemaVersion: 2.0.0
 
-commandTests:
-  - name: "ls_test"
-    command: "ls"
-    args: ["/usr/bin/"]
-    expectedOutput: ["."]
+fileExistenceTests:
   - name: "python2_test"
-    command: "which"
-    args: ["python"]
-    expectedOutput: ["/usr/bin/python"]
+    path: "/usr/bin/python"
+    shouldExist: true
   - name: "python3_test"
-    command: "which"
-    args: ["python3"]
-    expectedOutput: ["/usr/bin/python3"]
+    path: "/usr/bin/python3"
+    shouldExist: true
   - name: "pip_test"
-    command: "which"
-    args: ["pip"]
-    expectedOutput: ["/usr/bin/pip"]
+    path: "/usr/bin/pip"
+    shouldExist: true
   - name: "pip3_test"
-    command: "which"
-    args: ["pip3"]
-    expectedOutput: ["/usr/bin/pip3"]
+    path: "/usr/bin/pip3"
+    shouldExist: true
+
+# commandTests:
+#   - name: "ls_test"
+#     command: "ls"
+#     args: ["/usr/bin/"]
+#     expectedOutput: ["."]
+#   - name: "python2_test"
+#     command: "which"
+#     args: ["python"]
+#     expectedOutput: ["/usr/bin/python"]
+#   - name: "python3_test"
+#     command: "which"
+#     args: ["python3"]
+#     expectedOutput: ["/usr/bin/python3"]
+#   - name: "pip_test"
+#     command: "which"
+#     args: ["pip"]
+#     expectedOutput: ["/usr/bin/pip"]
+#   - name: "pip3_test"
+#     command: "which"
+#     args: ["pip3"]
+#     expectedOutput: ["/usr/bin/pip3"]


### PR DESCRIPTION
Download the python dependencies necessary for the awscli into the image. Ensure that `bash` is the entrypoint with a wrapper container, that is used for the installation.

Add tests to ensure that the python dependencies are installed on the image.

Pin image to digest rather than tag