### PR TITLE
Install the AWSCLI using container_run_and_commit

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 
 ## Packages
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -28,8 +28,23 @@ install_pkgs(
 ## Container
 
 container_image(
-    name = "awscli",
+    name = "pip_install",
     base = ":pkgs.tar",
+    cmd = "",
+    entrypoint = "",
+)
+
+container_run_and_commit(
+    name = "awscli_install",
+    commands = [
+        "pip install awscli",
+    ],
+    image = ":pip_install.tar",
+)
+
+container_image(
+    name = "awscli",
+    base = ":awscli_install.tar",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/BUILD
+++ b/src/BUILD
@@ -38,7 +38,7 @@ container_image(
 container_run_and_commit(
     name = "awscli_install",
     commands = [
-        "pip install awscli",
+        "python -m pip install --upgrade pip setuptools wheel awscli",
     ],
     image = ":pip_install.tar",
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -38,7 +38,8 @@ container_image(
 container_run_and_commit(
     name = "awscli_install",
     commands = [
-        "python -m pip install --upgrade pip setuptools wheel awscli",
+        "python -m pip install --upgrade pip setuptools wheel",
+        "python -m pip install awscli",
     ],
     image = ":pip_install.tar",
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -45,7 +45,7 @@ container_run_and_commit(
 
 container_image(
     name = "awscli",
-    base = ":awscli_install.tar",
+    base = ":awscli_install_commit.tar",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
     },

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -37,4 +37,4 @@ commandTests:
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli\..*"]
+    expectedOutput: ["aws-cli\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -37,4 +37,4 @@ commandTests:
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli\\..*"]
+    expectedError: ["aws-cli\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -37,4 +37,4 @@ commandTests:
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/\\d+\\..*"]
+    expectedOutput: ["aws-cli\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -37,4 +37,4 @@ commandTests:
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]
-    expectedError: ["aws-cli\\..*"]
+    expectedError: ["aws-cli\\/\\d+\\..*"]

--- a/src/test_configs/command.yaml
+++ b/src/test_configs/command.yaml
@@ -34,3 +34,7 @@ commandTests:
     command: "pip3"
     args: ["-V"]
     expectedOutput: ["pip \\d+\\..*"]
+  - name: "awscli_test"
+    command: "aws"
+    args: ["--version"]
+    expectedOutput: ["aws-cli/\\d+\\..*"]


### PR DESCRIPTION
Use `container_run_and_commit` to install `awscli` and the necessary dependencies.

In a production style image, the work of downloading and install pip packages would be done by rules like `pip_download` and `pip_install`. At the moment, this style doesn't pin any versions, and isn't really different from a dockerfile.